### PR TITLE
Multiple truncate support for Postgres

### DIFF
--- a/lib/adapter_extensions/adapters/abstract_adapter.rb
+++ b/lib/adapter_extensions/adapters/abstract_adapter.rb
@@ -5,7 +5,7 @@ module AdapterExtensions::AbstractAdapter
   def truncate(table_name, options=nil)
     statement = [
       'TRUNCATE TABLE',
-      table_name,
+      [table_name].flatten.join(','),
       options
     ].compact.join(' ')
     execute(statement)

--- a/test/abstract_adapter_test.rb
+++ b/test/abstract_adapter_test.rb
@@ -32,6 +32,13 @@ class AbstractAdapterTest < Test::Unit::TestCase
     assert_equal "TRUNCATE TABLE #{table_name}", adapter.query
   end
   
+  def test_multi_truncate
+    table_names = ['foo', 'bar']
+    adapter.truncate(table_names)
+    assert_equal "TRUNCATE TABLE #{table_names.join(',')}", adapter.query
+  end
+  
+  
   def test_support_select_into_table_should_return_false
     assert_equal false, adapter.support_select_into_table?
   end


### PR DESCRIPTION
This patch allows you to truncate multiple tables at once.

etl example

pre_process :truncate, :target => DATA_WAREHOUSE, :table => ['foo', 'bar']

This is necessary, at least in postgres because of foreign key constraints. 

This results in

TRUNCATE TABLE foo,bar
