### PR TITLE
Added a 'client' option for Postgres Bulk Load to support hosted environments.

### DIFF
--- a/lib/adapter_extensions/adapters/postgresql_adapter.rb
+++ b/lib/adapter_extensions/adapters/postgresql_adapter.rb
@@ -82,22 +82,20 @@ protected
   end
 
   def send_data_to_copy(file, conn, q, buffer_size)
-    conn.transaction do
-      conn.exec(q)
+    conn.exec(q)
 
-      buf = ''
-      io = File.open(file)
+    buf = ''
+    io = File.open(file)
 
-      begin
-        while io.read(buffer_size, buf)
-          until conn.put_copy_data(buf)
-            sleep 0.1
-          end
+    begin
+      while io.read(buffer_size, buf)
+        until conn.put_copy_data(buf)
+          sleep 0.1
         end
-      ensure
-        conn.put_copy_end
-        io.close
       end
+    ensure
+      conn.put_copy_end
+      io.close
     end
   end
 end

--- a/lib/adapter_extensions/adapters/postgresql_adapter.rb
+++ b/lib/adapter_extensions/adapters/postgresql_adapter.rb
@@ -96,7 +96,10 @@ protected
     ensure
       conn.put_copy_end
       io.close
-      conn.get_result.check
     end
+    
+    res = conn.get_result
+    STDOUT.puts "Copy Result: #{res.res_status(res.result_status)} on #{res.cmd_tuples}"
+    res.check
   end
 end

--- a/lib/adapter_extensions/adapters/postgresql_adapter.rb
+++ b/lib/adapter_extensions/adapters/postgresql_adapter.rb
@@ -1,22 +1,33 @@
 module AdapterExtensions::PostgreSQLAdapter
-  
+
   def support_select_into_table?
     true
   end
-  
+
   # Inserts an INTO table_name clause to the sql_query.
   def add_select_into_table(new_table_name, sql_query)
     sql_query.sub(/FROM/i, "INTO #{new_table_name} FROM")
   end
-  
+
   # Copy the specified table.
   def copy_table(old_table_name, new_table_name)
     execute add_select_into_table(new_table_name, "SELECT * FROM #{old_table_name}")
   end
 
 protected
+
+  def do_bulk_load(file, table_name, options={})
+    on_client = options.key?(:client) && options[:client]
+
+    if on_client
+      do_bulk_load_on_client(file, table_name, options)
+    else
+      do_bulk_load_on_server(file, table_name, options)
+    end
+  end
+
   # Call +bulk_load+, as that method wraps this method.
-  # 
+  #
   # Bulk load the data in the specified file.
   #
   # Options:
@@ -27,10 +38,36 @@ protected
   # * <tt>:delimited_by</tt> -- The field delimiter
   # * <tt>:null_string</tt> -- The string that should be interpreted as NULL (in addition to \N)
   # * <tt>:enclosed_by</tt> -- The field enclosure
-  def do_bulk_load(file, table_name, options={})
+  def do_bulk_load_on_server(file, table_name, options={})
+    q = build_copy_command(table_name, options, "'#{File.expand_path(file)}'")
+    execute(q)
+  end
+
+  DEFAULT_BUFFER_SIZE = 256
+
+  # Call +bulk_load+, as that method wraps this method.
+  #
+  # Bulk load the data in the specified file by streaming the data from the
+  # client. This makes bulk import possible on hosted services like Heroku.
+  #
+  # Options:
+  # * <tt>:ignore</tt> -- Ignore the specified number of lines from the source file. In the case of PostgreSQL
+  #   only the first line will be ignored from the source file regardless of the number of lines specified.
+  # * <tt>:columns</tt> -- Array of column names defining the source file column order
+  # * <tt>:fields</tt> -- Hash of options for fields:
+  # * <tt>:delimited_by</tt> -- The field delimiter
+  # * <tt>:null_string</tt> -- The string that should be interpreted as NULL (in addition to \N)
+  # * <tt>:enclosed_by</tt> -- The field enclosure
+  def do_bulk_load_on_client(file, table_name, options={})
+    q = build_copy_command(table_name, options, 'STDIN')
+    buffer_size = options[:buffer_size] || DEFAULT_BUFFER_SIZE
+    send_data_to_copy(file, @connection, q, buffer_size)
+  end
+
+  def build_copy_command(table_name, options, from)
     q = "COPY #{table_name} "
     q << "(#{options[:columns].join(',')}) " if options[:columns]
-    q << "FROM '#{File.expand_path(file)}' "
+    q << "FROM #{from} "
     if options[:fields]
       q << "WITH "
       q << "DELIMITER '#{options[:fields][:delimited_by]}' " if options[:fields][:delimited_by]
@@ -41,7 +78,26 @@ protected
         q << "QUOTE '#{options[:fields][:enclosed_by]}' " if options[:fields][:enclosed_by]
       end
     end
-    
-    execute(q)
+    q
+  end
+
+  def send_data_to_copy(file, conn, q, buffer_size)
+    conn.transaction do
+      conn.exec(q)
+
+      buf = ''
+      io = File.open(file)
+
+      begin
+        while io.read(buffer_size, buf)
+          until conn.put_copy_data(buf)
+            sleep 0.1
+          end
+        end
+      ensure
+        conn.put_copy_end
+        io.close
+      end
+    end
   end
 end

--- a/lib/adapter_extensions/adapters/postgresql_adapter.rb
+++ b/lib/adapter_extensions/adapters/postgresql_adapter.rb
@@ -43,7 +43,7 @@ protected
     execute(q)
   end
 
-  DEFAULT_BUFFER_SIZE = 256
+  DEFAULT_BUFFER_SIZE = 1024
 
   # Call +bulk_load+, as that method wraps this method.
   #
@@ -96,6 +96,7 @@ protected
     ensure
       conn.put_copy_end
       io.close
+      conn.get_result.check
     end
   end
 end

--- a/test/integration/postgresql_tests.rb
+++ b/test/integration/postgresql_tests.rb
@@ -1,4 +1,5 @@
 module PostgresqlTests
+
   def test_support_select_into_table_should_return_false
     # TODO: mock connection adapter?
     assert connection.support_select_into_table?
@@ -8,7 +9,7 @@ module PostgresqlTests
     connection.truncate('truncate_test', 'RESTART IDENTITY')
     assert_equal "0", connection.select_value("SELECT count(*) FROM truncate_test")
   end
-  
+
   def test_truncate_should_not_reset_identity_by_default
     blank_slate!
 
@@ -19,7 +20,7 @@ module PostgresqlTests
     # in this case the id should not be reset to 1
     assert_equal "2", connection.select_value("SELECT id FROM truncate_test")
   end
-  
+
   def test_truncate_should_reset_identity_if_requested
     blank_slate!
 
@@ -30,5 +31,22 @@ module PostgresqlTests
     # when using RESTART IDENTITY the id should be reset to 1
     assert_equal "1", connection.select_value("SELECT id FROM truncate_test")
   end
-  
+
+  def test_bulk_import_can_be_executed_by_the_db_server
+    connection.truncate('people')
+    assert_nothing_raised do
+      options = {:fields => {:delimited_by => ','}}
+      connection.bulk_load(File.join(File.dirname(__FILE__), 'people.csv'), 'people', options)
+    end
+    assert_equal 3, select_value("SELECT count(*) FROM people")
+  end
+
+  def test_bulk_import_can_be_executed_by_the_db_client
+    connection.truncate('people')
+    assert_nothing_raised do
+      options = {:fields => {:delimited_by => ','}, :client => true}
+      connection.bulk_load(File.join(File.dirname(__FILE__), 'people.csv'), 'people', options)
+    end
+    assert_equal 3, select_value("SELECT count(*) FROM people")
+  end
 end


### PR DESCRIPTION
We are using this with `activewarehouse-etl` on Heroku. Heroku does not support Postgres bulk copy directly from a file, but they do support streaming the data from STDIN. 

This change adds a `:client` option to the `bulk_load` method so that CSV data can be sent from the client to the server via STDIN instead of having the db directly access the file.

If the `:client` option is not specified, then `bulk_load` will behave as it did before.
